### PR TITLE
Chrome Stable + Docker lints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # single application.
 FROM gcr.io/google_appengine/nodejs
 LABEL name="bot-render" \ 
-			version="0.1" \
-			description="Renders a webpage for bot consumption (not production ready)"
+      version="0.1" \
+      description="Renders a webpage for bot consumption (not production ready)"
 
 RUN apt-get update && apt-get install -y \
   wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN /usr/local/bin/install_node '>=7.6'
 
 COPY . /app/
 
-# Add Chrome as a user
+# Add botrender as a user
 RUN groupadd -r botrender && useradd -r -g botrender -G audio,video botrender \
     && mkdir -p /home/botrender && chown -R botrender:botrender /home/botrender \
     && chown -R botrender:botrender /app
 
-# Run Chrome non-privileged
+# Run botrender non-privileged
 USER botrender
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,41 @@
 # Dockerfile extending the generic Node image with application files for a
 # single application.
 FROM gcr.io/google_appengine/nodejs
+LABEL name="bot-render" \ 
+			version="0.1" \
+			description="Renders a webpage for bot consumption (not production ready)"
+
 RUN apt-get update && apt-get install -y \
   wget \
+  --no-install-recommends \
+  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && apt-get update && apt-get install -y \
+  google-chrome-stable \
+  --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
-
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - 
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-
-RUN apt-get update && apt-get install -y \
-  google-chrome-beta \
-  && rm -rf /var/lib/apt/lists/*
-
 
 # Check to see if the the version included in the base runtime satisfies
 # '>=7.6', if not then do an npm install of the latest available
 # version that satisfies it.
 RUN /usr/local/bin/install_node '>=7.6'
+
 COPY . /app/
-# You have to specify "--unsafe-perm" with npm install
-# when running as root.  Failing to do this can cause
-# install to appear to succeed even if a preinstall
-# script fails, and may have other adverse consequences
-# as well.
-# This command will also cat the npm-debug.log file after the
-# build, if it exists.
-RUN npm install --unsafe-perm || \
+
+# Add Chrome as a user
+RUN groupadd -r botrender && useradd -r -g botrender -G audio,video botrender \
+    && mkdir -p /home/botrender && chown -R botrender:botrender /home/botrender \
+    && chown -R botrender:botrender /app
+
+# Run Chrome non-privileged
+USER botrender
+
+EXPOSE 8080
+
+RUN npm install || \
   ((if [ -f npm-debug.log ]; then \
       cat npm-debug.log; \
     fi) && false)
-CMD npm start
+
+ENTRYPOINT [ "npm" ]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ docker build -t bot-render . --no-cache=true
 ## Running the container
 
 There are two ways to run the container locally:
-1. With [Jessie Frazelle seccomp profile](https://github.com/jessfraz/dotfiles/blob/master/etc/docker/seccomp/chrome.json)
-2. With `--cap-add=SYS_ADMIN`
+1. [Recommended] - Use [Jessie Frazelle' seccomp profile](https://github.com/jessfraz/dotfiles/blob/master/etc/docker/seccomp/chrome.json) and `-security-opt` flag
+2. Utilize the `--cap-add SYS_ADMIN` flag
 
-If you do not use one of the options above, you will get `ECONNREFUSED` errors when trying to access the container as noted in issues [2](https://github.com/samuelli/bot-render/issues/2) and [3](https://github.com/samuelli/bot-render/issues/3).
+In the case where your kernel lacks user namespace support or are receiving a `ECONNREFUSED` error when trying to access the service in the container (as noted in issues [2](https://github.com/samuelli/bot-render/issues/2) and [3](https://github.com/samuelli/bot-render/issues/3)), both methods above should resolve the problem.
 
-Start a container with the built image using Jessie Frazelle seccomp profile for Chrome:
+[Recommended] Start a container with the built image using Jessie Frazelle' seccomp profile for Chrome:
 ```bash
 wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
 docker run -it -p 8080:8080 --security-opt seccomp=$HOME/chrome.json --name bot-render-container bot-render
@@ -49,7 +49,7 @@ docker run -it -p 8080:8080 --security-opt seccomp=$HOME/chrome.json --name bot-
 
 Start a container with the built image using SYS_ADMIN:
 ```bash
-docker run -it -p 8080:8080 --cap-add=SYS_ADMIN --name bot-render-container bot-render
+docker run -it -p 8080:8080 --cap-add SYS_ADMIN --name bot-render-container bot-render
 ```
 
 Send a request to the server running inside the container:

--- a/README.md
+++ b/README.md
@@ -33,14 +33,28 @@ After installing docker, build the docker image:
 docker build -t bot-render . --no-cache=true
 ```
 
-Start a container with the built image:
+## Running the container
+
+There are two ways to run the container locally:
+1. With [Jessie Frazelle seccomp profile](https://github.com/jessfraz/dotfiles/blob/master/etc/docker/seccomp/chrome.json)
+2. With `--cap-add=SYS_ADMIN`
+
+If you do not use one of the options above, you will get `ECONNREFUSED` errors when trying to access the container as noted in issues [2](https://github.com/samuelli/bot-render/issues/2) and [3](https://github.com/samuelli/bot-render/issues/3).
+
+Start a container with the built image using Jessie Frazelle seccomp profile for Chrome:
 ```bash
-docker run --name bot-render-container bot-render
+wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
+docker run -it -p 8080:8080 --security-opt seccomp=$HOME/chrome.json --name bot-render-container bot-render
+```
+
+Start a container with the built image using SYS_ADMIN:
+```bash
+docker run -it -p 8080:8080 --cap-add=SYS_ADMIN --name bot-render-container bot-render
 ```
 
 Send a request to the server running inside the container:
 ```bash
-docker exec bot-render-container curl http://localhost:8080/?url=https://dynamic-meta.appspot.com
+curl http://localhost:8080/?url=https://dynamic-meta.appspot.com
 ```
 
 Stop the container:

--- a/chromium.js
+++ b/chromium.js
@@ -4,13 +4,13 @@ const AdmZip = require('adm-zip');
 const execFile = require('child_process').execFile;
 
 function startChromium() {
-  const chromium = '/usr/bin/google-chrome-beta';
+  const chromium = '/usr/bin/google-chrome-stable';
   if (!fs.existsSync(chromium)) {
     console.error('Cannot find chromium');
     return false;
   }
 
-  execFile(chromium, ['--headless', '--disable-gpu', '--remote-debugging-port=9222']);
+  execFile(chromium, ['--headless', '--disable-gpu', '--remote-debugging-address=0.0.0.0', '--remote-debugging-port=9222']);
   return true;
 }
 


### PR DESCRIPTION
This patch does a few things:

1. Moves to Chrome Stable (since headless is now in 59).
2. Reduces the layer count in the docker file build.
3. Fixes lint errors in Dockerfile
4. Adds a non-privileged user called `botrender` to container (so you don't have to use `--unsafe-perm` with the npm install)
5. Expose 8080 for port binding and add documentation to allow running against service without `docker exec`
6. Document seccomp and SYS_ADMIN flags to reduce ECONNREFUSED confusion and use of `--disable-sandbox` as noted in #3 