### PR TITLE
Scoping shim is enabled using loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ directing requests to the bot-render service.
 
 If you are using web components v1 and either `webcomponents-lite.js` or `webcomponents-loader.js`,
 set the query parameter `wc-inject-shadydom=true` when directing requests to the bot-render
-service. This renderer service force the necessary polyfills to be loaded and enabled.
+service. This renderer service will force the necessary polyfills to be loaded and enabled.
 
 ## Middleware
 This is a list of middleware available to use with the bot-render service:

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ directing requests to the bot-render service.
 If you are using web components v1 and using `webcomponents-lite.js`, set the query parameter
 `wc-shadydom=true` to force shady dom on.
 
-If you are using web components v1 and `webcomponents-loader.js` or are not using any polyfill,
+If you are using web components v1 and `webcomponents-loader.js`,
 set the query parameter `wc-inject-shadydom=true` when directing requests to the bot-render
-service. This renderer service will then inject the Shady DOM polyfill and force it on.
+service. This renderer service force the necessary polyfills to be loaded and enabled.
 
 ## Middleware
 This is a list of middleware available to use with the bot-render service:

--- a/README.md
+++ b/README.md
@@ -100,10 +100,7 @@ render correctly. In Polymer 1.x, which uses web components v0, Shady DOM is ena
 If you are using Shadow DOM, override this by setting the query parameter `dom=shady` when
 directing requests to the bot-render service.
 
-If you are using web components v1 and using `webcomponents-lite.js`, set the query parameter
-`wc-shadydom=true` to force shady dom on.
-
-If you are using web components v1 and `webcomponents-loader.js`,
+If you are using web components v1 and either `webcomponents-lite.js` or `webcomponents-loader.js`,
 set the query parameter `wc-inject-shadydom=true` when directing requests to the bot-render
 service. This renderer service force the necessary polyfills to be loaded and enabled.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/datastore": "^1.0.6",
-    "@webcomponents/shadydom": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^1.0.3",
     "chrome-launcher": "^0.3.1",
     "chrome-remote-interface": "^0.24.1",

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const CDP = require('chrome-remote-interface');
-const fs = require('fs');
 
 /**
  * Executed on the page after the page has loaded. Strips script and

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2,7 +2,6 @@
 
 const CDP = require('chrome-remote-interface');
 const fs = require('fs');
-const shadyDomPolyfill = fs.readFileSync(require.resolve('@webcomponents/shadydom'), 'utf8');
 
 /**
  * Executed on the page after the page has loaded. Strips script and
@@ -35,8 +34,9 @@ function render(url, injectShadyDom) {
     //   addScriptToEvaluateOnNewDocument({source: `ShadyDOM = {force: true}`})
     if (injectShadyDom) {
       // Deprecated in Chrome 61.
+      Page.addScriptToEvaluateOnLoad({scriptSource: `customElements.forcePolyfill = true`});
       Page.addScriptToEvaluateOnLoad({scriptSource: `ShadyDOM = {force: true}`});
-      Page.addScriptToEvaluateOnLoad({scriptSource: shadyDomPolyfill});
+      Page.addScriptToEvaluateOnLoad({scriptSource: `ShadyCSS = {shimcssproperties: true}`});
     }
 
     Page.navigate({url: url});

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -56,8 +56,7 @@ test('renders shadow DOM - polyfill loader', async(t) => {
 test('renders shadow DOM - webcomponents-lite.js polyfill', async(t) => {
   const server = await createServer();
   const testFile = path.resolve(__dirname, 'resources/shadow-dom-polyfill-all.html');
-  const url = 'file://' + testFile + '?wc-shadydom=true';
-  const res = await server.get('/?url=' + encodeURIComponent(url));
+  const res = await server.get('/?url=file://' + testFile + '&wc-inject-shadydom=true');
   t.is(res.status, 200);
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -37,6 +37,8 @@ test('renders script after page load event', async(t) => {
   t.true(res.text.indexOf('injectedElement') != -1);
 });
 
+// This test is failing as the polyfills (shady polyfill & scoping shim) are not
+// yet injected properly.
 test.failing('renders shadow DOM - no polyfill', async(t) => {
   const server = await createServer();
   const testFile = path.resolve(__dirname, 'resources/shadow-dom-no-polyfill.html');

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -37,7 +37,7 @@ test('renders script after page load event', async(t) => {
   t.true(res.text.indexOf('injectedElement') != -1);
 });
 
-test('renders shadow DOM - no polyfill', async(t) => {
+test.failing('renders shadow DOM - no polyfill', async(t) => {
   const server = await createServer();
   const testFile = path.resolve(__dirname, 'resources/shadow-dom-no-polyfill.html');
   const res = await server.get('/?url=file://' + testFile + '&wc-inject-shadydom=true');
@@ -45,7 +45,7 @@ test('renders shadow DOM - no polyfill', async(t) => {
   t.true(res.text.indexOf('shadow-root-text') != -1);
 });
 
-test('renders shadow DOM - no polyfill', async(t) => {
+test('renders shadow DOM - polyfill loader', async(t) => {
   const server = await createServer();
   const testFile = path.resolve(__dirname, 'resources/shadow-dom-polyfill-loader.html');
   const res = await server.get('/?url=file://' + testFile + '&wc-inject-shadydom=true');


### PR DESCRIPTION
Fixes #18.

Scoping shim is required to properly serialize styles. However, injecting the scoping shim doesn't work since nothing on the document exists yet. As such, this enables the scoping shim but requires `webcomponents-loader.js` to work.