### PR TITLE
Scan ports and use a new port on every instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "chrome-remote-interface": "^0.24.1",
     "command-line-args": "^4.0.6",
     "compression": "^1.7.0",
-    "express": "^4.15.2"
+    "express": "^4.15.2",
+    "portscanner": "^2.1.1"
   },
   "devDependencies": {
     "ava": "^0.20.0",

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ const chromeLauncher = require('chrome-launcher');
 const express = require('express');
 const compression = require('compression');
 const commandLineArgs = require('command-line-args');
+const portscanner = require('portscanner');
 const app = express();
 const cache = require('./cache');
 
@@ -34,10 +35,19 @@ app.get('/', async function(request, response) {
 
 app.get('/_ah/health', (request, response) => response.send('OK'));
 
-const appPromise = chromeLauncher.launch({
-  chromeFlags: ['--headless', '--disable-gpu', '--remote-debugging-address=0.0.0.0'],
-  port: 9222
+app.get('/_ah/stop', async(request, response) => {
+  await config.chrome.kill();
+  response.send('OK')
+});
+
+const appPromise = portscanner.findAPortNotInUse(9000, 15000, '127.0.0.1').then((port) => {
+  config.port = port;
+  return chromeLauncher.launch({
+    chromeFlags: ['--headless', '--disable-gpu', '--remote-debugging-address=0.0.0.0'],
+    port: port
+  });
 }).then((chrome) => {
+  config.chrome = chrome;
   // Don't open a port when running from inside a module (eg. tests). Importing
   // module can control this.
   const port = process.env.PORT || '3000';

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ app.get('/_ah/health', (request, response) => response.send('OK'));
 
 app.get('/_ah/stop', async(request, response) => {
   await config.chrome.kill();
-  response.send('OK')
+  response.send('OK');
 });
 
 const appPromise = portscanner.findAPortNotInUse(9000, 15000, '127.0.0.1').then((port) => {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -24,8 +24,8 @@ function stripPage() {
 
 function render(url, injectShadyDom, config) {
   return new Promise(async(resolve, reject) => {
-    const tab = await CDP.New();
-    const client = await CDP({tab: tab});
+    const tab = await CDP.New({port: config.port});
+    const client = await CDP({tab: tab, port: config.port});
 
     const {Page, Runtime, Network, Emulation, Console} = client;
 
@@ -110,7 +110,7 @@ function render(url, injectShadyDom, config) {
         statusCode = result.result.value;
 
       result = await Runtime.evaluate({expression: 'document.firstElementChild.outerHTML'});
-      CDP.Close({id: client.target.id});
+      CDP.Close({id: client.target.id, port: config.port});
       resolve({
         status: statusCode || 200,
         body: result.result.value});

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,10 +113,6 @@
   version "6.0.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.66.tgz#5680b74a6135d33d4c00447e7c3dc691a4601625"
 
-"@webcomponents/shadydom@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@webcomponents/shadydom/-/shadydom-1.0.0.tgz#404366cf92aa175c22cfdb1c5d0d364a9cbb0108"
-
 "@webcomponents/webcomponentsjs@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.3.tgz#632514dda2252c0b1cfa3ae9f641477fa9084e5d"
@@ -298,6 +294,10 @@ assert-plus@^0.2.0:
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+
+async@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.1.2, async@^2.3.0, async@^2.4.0:
   version "2.5.0"
@@ -2162,6 +2162,12 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
+is-number-like@^1.0.3:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/is-number-like/-/is-number-like-1.0.8.tgz#2e129620b50891042e44e9bbbb30593e75cfbbe3"
+  dependencies:
+    lodash.isfinite "^3.3.2"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2511,6 +2517,10 @@ lodash.isarray@^3.0.0:
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.isfinite@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -3100,6 +3110,13 @@ plur@^2.0.0:
 pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+
+portscanner@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/portscanner/-/portscanner-2.1.1.tgz#eabb409e4de24950f5a2a516d35ae769343fbb96"
+  dependencies:
+    async "1.5.2"
+    is-number-like "^1.0.3"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
When running on Google Cloud, instances are automatically scaled. However, because it was always using the default remote debugging port (9222) to talk to Chrome, these instances could block each other from functioning as expected.

This change ensures each instance finds its own available port to use for remote debugging.