### PR TITLE
Inject <base href> tag into page to allow output to be rendered nicely

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -25,6 +25,7 @@ function stripPage() {
 /**
  * Injects a <base> tag which allows other resources to load. This
  * has no effect on serialised output, but allows it to verify render quality.
+ * @param {string} url - Requested URL to set as the base.
  */
 function injectBaseHref(url) {
   const base = document.createElement('base');

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -22,6 +22,25 @@ function stripPage() {
   elements.forEach((e) => e.remove());
 }
 
+/**
+ * Injects a <base> tag which allows other resources to load. This
+ * has no effect on serialised output, but allows it to verify render quality.
+ */
+function injectBaseHref(url) {
+  const base = document.createElement('base');
+  base.setAttribute('href', url);
+  document.head.appendChild(base);
+}
+
+/**
+ * Executed on the page after the page has loaded. Strips script and
+ * import tags to prevent further loading of resources.
+ */
+function stripPage() {
+  const elements = document.querySelectorAll('script, link[rel=import]');
+  elements.forEach((e) => e.remove());
+}
+
 function render(url, injectShadyDom, config) {
   return new Promise(async(resolve, reject) => {
     const tab = await CDP.New();
@@ -108,6 +127,7 @@ function render(url, injectShadyDom, config) {
       // status code, regardless of meta tags.
       if ((statusCode == 200 || statusCode == 304) && result.result.value)
         statusCode = result.result.value;
+      result = await Runtime.evaluate({expression: `(${injectBaseHref.toString()})('${url}')`});
 
       result = await Runtime.evaluate({expression: 'document.firstElementChild.outerHTML'});
       CDP.Close({id: client.target.id});


### PR DESCRIPTION
This is a purely cosmetic change. With the base href set, when previewing output from the service, resources like images will be able to resolve to the original server correctly. This doesn't affect the serialised output, except for the addition of the base tag.