### PR TITLE
Beef up instance capabilities

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,2 +1,4 @@
 runtime: custom
 env: flex
+resources:
+  cpu: 8

--- a/app.yaml
+++ b/app.yaml
@@ -2,3 +2,4 @@ runtime: custom
 env: flex
 resources:
   cpu: 8
+  memory_gb: 28


### PR DESCRIPTION
This will change instance machine types to `n1-standard-8`, which should improve render times.

Reference: https://cloud.google.com/compute/docs/machine-types
