### PR TITLE
Restrict screenshot size and speed up animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The `render` endpoint will render your page and serialize your page. Available o
 
 The `screenshot` endpoint can be used to verify that your page is rendering correctly.
 Available options:
- * `width` default `1000` - used to set the viewport width
- * `height` default `1000` - used to set the viewport height
+ * `width` default `1000` - used to set the viewport width (max 1500)
+ * `height` default `1000` - used to set the viewport height (max 1500)
 
 ## FAQ
 


### PR DESCRIPTION
 * Screenshots are restricted to 1500*1500 since compression for PNG screenshots is not available. Source: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot
 * Animations are sped up to 1000x to alleviate issues where screenshots are taken when the page is loaded but there are still loading animations on screen.
 * Fix an exception where budget can end up being a non-integer value.