### PR TITLE
Enable browser cache

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -23,8 +23,6 @@ class Renderer {
         Runtime.enable(),
         Console.enable(),
         Network.enable(),
-        Network.clearBrowserCache(),
-        Network.setCacheDisabled({cacheDisabled: true}),
         Network.setBypassServiceWorker({bypass: true}),
       ]);
 


### PR DESCRIPTION
Closes #51.

This change enables the browser cache since the browser respects the caching headers set by servers. As with regular users, its the servers responsibility to set the right caching headers. This improves performance on different pages within the same application.