### PR TITLE
Load config from config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN npm install || \
     fi) && false)
 
 ENTRYPOINT [ "npm" ]
-CMD ["run", "start-prod"]
+CMD ["run", "start"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ bots.
   - [Web components](#web-components)
   - [Status codes](#status-codes)
 - [Installing & deploying](#installing--deploying)
+  - [Config](#config)
 
 ## Middleware
 Once you have the service up and running, you'll need to implement the differential serving
@@ -89,6 +90,13 @@ set the HTTP status returned by the rendering service by adding a meta tag.
 ```
 
 ## Installing & deploying
+
+### Config
+When deploying the service, set configuration variables by including a `config.json` in the
+root. Available configuration options:
+ * `cache` default `false` - set to `true` to enable caching on Google Cloud using datastore
+ * `debug` default `false` - set to `true` to log console messages from within the
+ rendered pages.
 
 ### Dependencies
 This project requires Node 7+ and Docker ([installation instructions](https://docs.docker.com/engine/installation/)). For deployment this

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@webcomponents/webcomponentsjs": "^1.0.3",
     "chrome-launcher": "^0.3.1",
     "chrome-remote-interface": "^0.24.1",
-    "command-line-args": "^4.0.6",
     "compression": "^1.7.0",
     "express": "^4.15.2"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "main": "src/main.js",
   "scripts": {
     "start": "node src/main.js",
-    "start-prod": "node src/main.js --cache",
     "lint": "eslint src/*.js test/*.js",
     "monitor": "nodemon src/main.js",
     "monitor-inspect": "nodemon --inspect src/main.js",

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -49,7 +49,7 @@ class Renderer {
       // Add hook for completion event.
       Page.addScriptToEvaluateOnLoad({scriptSource: `(${listenForCompletionEvent.toString()})()`});
 
-      if (config.debug) {
+      if (!!config['debug']) {
         Console.messageAdded((event) => {
           console.log(`[${event.message.level}] ${event.message.text}`);
         });


### PR DESCRIPTION
Closes #36.

Refactor to use config.json instead of command line options.